### PR TITLE
enhance docker-compose examples

### DIFF
--- a/unbound/examples/docker-compose.yaml-bridge
+++ b/unbound/examples/docker-compose.yaml-bridge
@@ -1,11 +1,11 @@
-#Sample docker-compose.yaml deploying Pi-hole and Unbound 
-#with a Bridged Network.
-#This example needs to be modified to reflect your network environment,
-#especially the values in angle brackets (<>) must be adapted to your needs.
-#This file is the one I'm using and was slightly modified with added IPv6
-#support (which I'm not using currently).
+# Sample docker-compose.yaml deploying Pi-hole and Unbound
+# with a Bridged Network.
+# This example needs to be modified to reflect your network environment,
+# especially the values in angle brackets (<>) must be adapted to your needs.
+# This file is the one I'm using and was slightly modified with added IPv6
+# support (which I'm not using currently).
 
-version: '2'
+version: '3'
 
 services:
   pihole:
@@ -37,7 +37,7 @@ services:
       TZ: <YOURTIMEZONE> #e.g. "America/New_York"
       CORS_HOSTS: <yourdomain.lan>
       PIHOLE_DNS_: <UNBOUND_IP_ADDRESS#5335> #e.g. 192.168.1.253#5335 or fd11:aa:1234:1234::505#5335
-      IPv6: <"false"> #Enable if using IPv6, uncomment and set IPv6-adresses for pi-hole and unbound, uncomment and edit the "networks" section below accordingly  
+      IPv6: <"false"> #Enable if using IPv6, uncomment and set IPv6-adresses for pi-hole and unbound, uncomment and edit the "networks" section below accordingly
       DNS_BOGUS_PRIV: <"true"> #Enable forwarding of reverse lookups for private ranges
       DNS_FQDN_REQUIRED: <"true"> #Never forward non-FQDNs
       REV_SERVER: <"true"> #Use Conditional Forwarding
@@ -47,7 +47,7 @@ services:
     volumes:
       - <LOCAL_PIHOLE_VOLUME_PATH>:/etc/:rw #Your local path to Pi-hole
     restart: unless-stopped
-     
+
   unbound:
     container_name: unbound
     image: madnuttah/unbound:latest
@@ -60,16 +60,16 @@ services:
       dns-network:
         ipv4_address: <UNBOUND_IPv4_ADDRESS> #e.g. 172.20.0.253
         #ipv6_address: <UNBOUND_IPv6_ADDRESS> #e.g. fd11:aa:1234:1234::505
-    environment: 
+    environment:
       TZ: <YOURTIMEZONE> #e.g. "America/New_York"
       ServerIP: <UNBOUND_IP_ADDRESS> #e.g. 172.20.0.253 or fd11:aa:1234:1234::505
       VIRTUAL_HOST: <unbound.yourdomain.lan>
-    volumes:       
-      - <LOCAL_UNBOUND_VOLUME_PATH>/unbound.conf:/usr/local/unbound/unbound.conf:rw #Your local path to Unbound
-      - <LOCAL_UNBOUND_VOLUME_PATH>/conf.d/:/usr/local/unbound/conf.d/:rw
-      - <LOCAL_UNBOUND_VOLUME_PATH>/iana.d/:/usr/local/unbound/iana.d/:rw
-      - <LOCAL_UNBOUND_VOLUME_PATH>/log.d/unbound.log:/usr/local/unbound/log.d/unbound.log:rw
-      - <LOCAL_UNBOUND_VOLUME_PATH>/zones.d/:/usr/local/unbound/zones.d/:rw
+    volumes:
+      - ./unbound.conf:/usr/local/unbound/unbound.conf:rw #Your local path to Unbound
+      - ./conf.d/:/usr/local/unbound/conf.d/:rw
+      - ./iana.d/:/usr/local/unbound/iana.d/:rw
+      - ./log.d/unbound.log:/usr/local/unbound/log.d/unbound.log:rw
+      - ./zones.d/:/usr/local/unbound/zones.d/:rw
     restart: unless-stopped
     healthcheck:
       test: /usr/local/sbin/healthcheck.sh
@@ -77,7 +77,7 @@ services:
       retries: 5
       start_period: 15s
       timeout: 30s
-    
+
 networks:
   dns-network:
     #enable_ipv6: <false> #Enable if using IPv6
@@ -86,7 +86,7 @@ networks:
       parent: <eth0> #Your parent network interface
     ipam:
       config:
-        - subnet: <IPv4_SUBNET> #e.g. 172.20.0.0/24     
-          gateway: <GATEWAY_IPv4_ADDRESS> #e.g. 172.20.0.1  
+        - subnet: <IPv4_SUBNET> #e.g. 172.20.0.0/24
+          gateway: <GATEWAY_IPv4_ADDRESS> #e.g. 172.20.0.1
         #- subnet: <IPv6_SUBNET> #e.g. fd11:aa:1234:1234::/126
-        # gateway: <GATEWAY_IPv6_ADDRESS> #e.g. fd11:aa:1234:1234::11   
+        # gateway: <GATEWAY_IPv6_ADDRESS> #e.g. fd11:aa:1234:1234::11

--- a/unbound/examples/docker-compose.yaml-macvlan
+++ b/unbound/examples/docker-compose.yaml-macvlan
@@ -1,12 +1,12 @@
-#Sample docker-compose.yaml deploying Pi-hole and Unbound
-#with a macvlan Network and an additional bridge network to enable host
-#container communication.
-#This example needs to be modified to reflect your network environment,
-#especially the values in angle brackets (<>) must be adapted to your needs.
-#This file is the one I'm using and was slightly modified with added IPv6
-#support (which I'm not using currently).
+# Sample docker-compose.yaml deploying Pi-hole and Unbound
+# with a macvlan Network and an additional bridge network to enable host
+# container communication.
+# This example needs to be modified to reflect your network environment,
+# especially the values in angle brackets (<>) must be adapted to your needs.
+# This file is the one I'm using and was slightly modified with added IPv6
+# support (which I'm not using currently).
 
-version: '2'
+version: '3'
 
 services:
   pihole:
@@ -22,10 +22,10 @@ services:
       - NET_BIND_SERVICE
     networks:
       dns-network:
-        ipv4_address: <PI_HOLE_IPv4_ADDRESS> #e.g. 192.168.1.254 
+        ipv4_address: <PI_HOLE_IPv4_ADDRESS> #e.g. 192.168.1.254
         #ipv6_address: <PI_HOLE_IPv6_ADDRESS> #e.g. fd11:aa:1234:1234::506
       dns-bridge:
-        ipv4_address: <PI_HOLE_IPv4_ADDRESS> #e.g. 192.168.0.254 
+        ipv4_address: <PI_HOLE_IPv4_ADDRESS> #e.g. 192.168.0.254
         #ipv6_address: <PI_HOLE_IPv6_ADDRESS> #e.g. fd11:aa:1234:1234::506
     dns:
       - <UNBOUND_IP_ADDRESS> #e.g. 192.168.1.253 or fd11:aa:1234:1234::505
@@ -42,7 +42,7 @@ services:
       TZ: <YOURTIMEZONE> #e.g. "America/New_York"
       CORS_HOSTS: <yourdomain.lan>
       PIHOLE_DNS_: <UNBOUND_IP_ADDRESS#5335> #e.g. 192.168.1.253#5335 or fd11:aa:1234:1234::505#5335
-      IPv6: <"false"> #Enable if using IPv6, uncomment and set IPv6-adresses for pi-hole and unbound, uncomment and edit the "networks" section below accordingly  
+      IPv6: <"false"> #Enable if using IPv6, uncomment and set IPv6-adresses for pi-hole and unbound, uncomment and edit the "networks" section below accordingly
       DNS_BOGUS_PRIV: <"true"> #Enable forwarding of reverse lookups for private ranges
       DNS_FQDN_REQUIRED: <"true"> #Never forward non-FQDNs
       REV_SERVER: <"true"> #Use Conditional Forwarding
@@ -52,7 +52,7 @@ services:
     volumes:
       - <LOCAL_PIHOLE_VOLUME_PATH>:/etc/:rw #Your local path to Pi-hole
     restart: unless-stopped
-     
+
   unbound:
     container_name: unbound
     image: madnuttah/unbound:latest
@@ -66,16 +66,16 @@ services:
       dns-network:
         ipv4_address: <UNBOUND_IPv4_ADDRESS> #e.g. 192.168.1.253
         #ipv6_address: <UNBOUND_IPv6_ADDRESS> #e.g. fd11:aa:1234:1234::505
-    environment: 
+    environment:
       TZ: <YOURTIMEZONE> #e.g. "America/New_York"
       ServerIP: <UNBOUND_IP_ADDRESS> #e.g. 192.168.1.253 or fd11:aa:1234:1234::505
       VIRTUAL_HOST: <unbound.yourdomain.lan>
-    volumes:       
-      - <LOCAL_UNBOUND_VOLUME_PATH>/unbound.conf:/usr/local/unbound/unbound.conf:rw #Your local path to Unbound
-      - <LOCAL_UNBOUND_VOLUME_PATH>/conf.d/:/usr/local/unbound/conf.d/:rw
-      - <LOCAL_UNBOUND_VOLUME_PATH>/iana.d/:/usr/local/unbound/iana.d/:rw
-      - <LOCAL_UNBOUND_VOLUME_PATH>/log.d/unbound.log:/usr/local/unbound/log.d/unbound.log:rw
-      - <LOCAL_UNBOUND_VOLUME_PATH>/zones.d/:/usr/local/unbound/zones.d/:rw
+    volumes:
+      - ./unbound.conf:/usr/local/unbound/unbound.conf:rw #Your local path to Unbound
+      - ./conf.d/:/usr/local/unbound/conf.d/:rw
+      - ./iana.d/:/usr/local/unbound/iana.d/:rw
+      - ./log.d/unbound.log:/usr/local/unbound/log.d/unbound.log:rw
+      - ./zones.d/:/usr/local/unbound/zones.d/:rw
     healthcheck:
       test: /usr/local/sbin/healthcheck.sh
       interval: 60s
@@ -91,16 +91,16 @@ networks:
       parent: <eth0> #Your parent network interface
     ipam:
       config:
-        - subnet: <IPv4_SUBNET> #e.g. 192.168.1.0/24      
-          gateway: <GATEWAY_IPv4_ADDRESS> #e.g. 192.168.1.1    
-          ip_range: <IPv4_NETWORK_RANGE> #e.g. 192.168.1.253/30 
+        - subnet: <IPv4_SUBNET> #e.g. 192.168.1.0/24
+          gateway: <GATEWAY_IPv4_ADDRESS> #e.g. 192.168.1.1
+          ip_range: <IPv4_NETWORK_RANGE> #e.g. 192.168.1.253/30
         #- subnet: <IPv6_SUBNET> #e.g. fd11:aa:1234:1234::/127
-        # gateway: <GATEWAY_IPv6_ADDRESS> #e.g. fd11:aa:1234:1234::11     
-  
+        # gateway: <GATEWAY_IPv6_ADDRESS> #e.g. fd11:aa:1234:1234::11
+
   dns-bridge:
     #enable_ipv6: <false> #Enable if using IPv6
     driver: bridge
     ipam:
       config:
-        - subnet: <IPv4_SUBNET> #e.g. 192.168.0.0/16        
-        #- subnet: <IPv6_SUBNET> #e.g. fd11:bb:1234:1234::/126        
+        - subnet: <IPv4_SUBNET> #e.g. 192.168.0.0/16
+        #- subnet: <IPv6_SUBNET> #e.g. fd11:bb:1234:1234::/126

--- a/unbound/examples/docker-compose.yaml-minimal
+++ b/unbound/examples/docker-compose.yaml-minimal
@@ -1,0 +1,27 @@
+# minimal docker-compose.yaml
+#
+# just start unbound for a quick check
+
+version: '3'
+
+services:
+  unbound:
+    container_name: unbound
+    image: madnuttah/unbound:latest
+    ports:
+      - 5335:5335/tcp
+      - 5335:5335/udp
+#   volumes:
+#     - ./unbound.conf:/usr/local/unbound/unbound.conf:rw
+#     - ./conf.d/:/usr/local/unbound/conf.d/:rw
+#     - ./iana.d/:/usr/local/unbound/iana.d/:rw
+#     - ./log.d/unbound.log:/usr/local/unbound/log.d/unbound.log:rw
+#     - ./zones.d/:/usr/local/unbound/zones.d/:rw
+    restart: unless-stopped
+    healthcheck:
+      test: /usr/local/sbin/healthcheck.sh
+      interval: 60s
+      retries: 5
+      start_period: 15s
+      timeout: 30s
+


### PR DESCRIPTION
* rename example files - spaces and brackets in filenames are problematic
* change compose version 2->3 which gives the option to have relative filenames for volumes
* add a minimal docker-compose file
* remove trailing whitespace