### PR TITLE
fix: 'lru' not being a supported value by redis

### DIFF
--- a/doc/examples/redis/redis.conf
+++ b/doc/examples/redis/redis.conf
@@ -1155,7 +1155,7 @@
     #
     # The default is:
     #
-    maxmemory-policy lru
+    maxmemory-policy allkeys-lru
     
     # LRU, LFU and minimal TTL algorithms are not precise algorithms but approximated
     # algorithms (in order to save memory), so you can tune it for speed or


### PR DESCRIPTION
**- What I did**
Changed the value 'lru' to 'allkeys-lru'
Fixes #73 

**- Description for the changelog**
Fix incorrect value for the max memory policy in redis
