### PR TITLE
fix: allow overriding configuration with include directives 

### DIFF
--- a/doc/examples/usr/local/unbound/unbound.conf
+++ b/doc/examples/usr/local/unbound/unbound.conf
@@ -1,6 +1,3 @@
-include: "/usr/local/unbound/conf.d/*.conf"
-include: "/usr/local/unbound/zones.d/*.conf"
-
 server:
 	module-config: "validator iterator"
 	username: ""
@@ -8,3 +5,6 @@ server:
 	chroot: ""
 	do-daemonize: no
 	tls-cert-bundle: /etc/ssl/certs/ca-certificates.crt
+
+include: "/usr/local/unbound/conf.d/*.conf"
+include: "/usr/local/unbound/zones.d/*.conf"

--- a/unbound/root/usr/local/unbound/unbound.conf
+++ b/unbound/root/usr/local/unbound/unbound.conf
@@ -8,9 +8,6 @@
 # Use this anywhere in the file to include other text into this file.
 #include: "otherfile.conf"
 
-include: "/usr/local/unbound/conf.d/*.conf"
-include: "/usr/local/unbound/zones.d/*.conf"
-
 # Use this anywhere in the file to include other text, that explicitly starts a
 # clause, into this file. Text after this directive needs to start a clause.
 #include-toplevel: "otherfile.conf"
@@ -1319,3 +1316,7 @@ auth-zone:
 #     rpz-signal-nxdomain-ra: no
 #     for-downstream: no
 #     tags: "example"
+
+# Allow to include other config files that override settings made here
+include: "/usr/local/unbound/conf.d/*.conf"
+include: "/usr/local/unbound/zones.d/*.conf"


### PR DESCRIPTION
<!--
Please make sure you've read and understood my [`Contributing Guidelines`](https://github.com/madnuttah/unbound-docker/blob/main/CONTRIBUTING.md)

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

## Motivation – Problem Statement
The current setup uses the `include:` directive to allow structuring the unbound configuration while keeping a small footprint in the central `unbound.conf` configuration file. However, the inbuilt as well as the example `unbound.conf` files do not allow overriding values set in the central `unbound.conf` configuration file. That's because the `include:` directive is placed _before_ central configuration.

Current inbuilt `unbound.conf` file (redacted) with `include:`s at the top:

https://github.com/madnuttah/unbound-docker/blob/82b7e113990ac25581d8a4eb0c8cf53ec2f6e3df/unbound/root/usr/local/unbound/unbound.conf#L8-L23

The current solution does not allow overriding the `verbosity` attribute in an include because the central definition `verbosity: 1` (line 23) is mentioned _after_ the includes (lines 11-12), making this "meant to be" _default_ a "not changeable" _hardcoding_. See "verify" section.

## What I did – Solution
This change moves the `include:` directives to the end of the central `unbound.conf` configuration file, thus allowing overriding values set previously, making the docker container more flexible to local needs.

## How to verify it

### Simple way

You could verify this behaviour by simple adding a `verbosity: 2` statement before and after the inbuilt `verbosity: 1`
statement selecitvely to verify this behaviour.

```yaml
include: "/usr/local/unbound/conf.d/*.conf"

# will get ignored because it's getting overriden later
server:
    verbosity: 2

# The server clause sets the main parameters.
server:
    # whitespace is not necessary, but looks cleaner.

    # verbosity number, 0 is least verbose. 1 is default.
    verbosity: 1

# works and will override the statement made before
server:
    verbosity: 2
```

### Baseline – no additional logging configuration

A more exhaustive configuration is shown in the following.

#### unbound.conf
```yaml
include-toplevel: "/usr/local/unbound/conf.d/*.conf"
include-toplevel: "/usr/local/unbound/zones.d/*.conf"
server:
    interface: 0.0.0.0
    interface: ::0
    module-config: "validator iterator"
    username: ""
    directory: "/usr/local/unbound"
    chroot: ""
    do-daemonize: no
    tls-cert-bundle: /etc/ssl/certs/ca-certificates.crt	
    port: 5335
    verbosity: 1
```

#### Log output (baseline)
```log

(Redacted) log of baseline configuration:
...
[1760248147] unbound[7:0] warning: so-sndbuf 4194304 was not granted. Got 425984. To fix: start with root permissions(linux) or sysctl bigger net.core.wmem_max(linux) or kern.ipc.maxsockbuf(bsd) values. or set so-sndbuf: 0 (use system value).
[1760248147] unbound[7:0] warning: so-sndbuf 4194304 was not granted. Got 425984. To fix: start with root permissions(linux) or sysctl bigger net.core.wmem_max(linux) or kern.ipc.maxsockbuf(bsd) values. or set so-sndbuf: 0 (use system value).
```

### Example logging include

Example `conf.d/logging.conf` enabling logging of queries, directing all output to `stderr` instaed of to syslog, and increasing the `verbosity` log level (from 1 to 2).
```yaml
server:
    log-queries: yes
    use-syslog: no
    verbosity: 2
```


#### Logging output (missing the higher verbosity)

While the query logging is reflected in the enriched logging, the verbosity is still low. 
```
...
[1760248598] unbound[7:0] warning: so-sndbuf 4194304 was not granted. Got 425984. To fix: start with root permissions(linux) or sysctl bigger net.core.wmem_max(linux) or kern.ipc.maxsockbuf(bsd) values. or set so-sndbuf: 0 (use system value).
[1760248598] unbound[7:0] warning: so-sndbuf 4194304 was not granted. Got 425984. To fix: start with root permissions(linux) or sysctl bigger net.core.wmem_max(linux) or kern.ipc.maxsockbuf(bsd) values. or set so-sndbuf: 0 (use system value).
[1760248598] unbound[7:0] notice: init module 0: validator
[1760248598] unbound[7:0] notice: init module 1: iterator
[1760248599] unbound[7:0] info: start of service (unbound 1.24.0).
[1760248603] unbound[7:0] info: 10.244.2.172 github.com. A IN
[1760248621] unbound[7:0] info: service stopped (unbound 1.24.0).
...
```

### Rectified solution

#### unbound.conf
```yaml
server:
    interface: 0.0.0.0
    interface: ::0
    module-config: "validator iterator"
    username: ""
    directory: "/usr/local/unbound"
    chroot: ""
    do-daemonize: no
    tls-cert-bundle: /etc/ssl/certs/ca-certificates.crt	
    port: 5335
    verbosity: 1
# Allow to include other config files that override settings made before
include: "/usr/local/unbound/conf.d/*.conf"
include: "/usr/local/unbound/zones.d/*.conf"
```

#### Logging output (more verbose)

When moving the `include` directive to the end of the file (or placing a `verbosity: 2` statement after the central one), the increased verbosity setting gets reflected in the logs:
```
...
[1760248620] unbound[7:0] warning: so-sndbuf 4194304 was not granted. Got 425984. To fix: start with root permissions(linux) or sysctl bigger net.core.wmem_max(linux) or kern.ipc.maxsockbuf(bsd) values. or set so-sndbuf: 0 (use system value).
[1760248620] unbound[7:0] warning: so-sndbuf 4194304 was not granted. Got 425984. To fix: start with root permissions(linux) or sysctl bigger net.core.wmem_max(linux) or kern.ipc.maxsockbuf(bsd) values. or set so-sndbuf: 0 (use system value).
[1760248620] unbound[7:0] notice: init module 0: validator
[1760248620] unbound[7:0] notice: init module 1: iterator
[1760248620] unbound[7:0] info: start of service (unbound 1.24.0).
[1760248636] unbound[7:0] info: 10.244.2.172 github.com. A IN
[1760248636] unbound[7:0] info: resolving github.com. A IN
[1760248636] unbound[7:0] info: priming . IN NS
[1760248636] unbound[7:0] info: response for . NS IN
[1760248636] unbound[7:0] info: reply from <.> 192.5.5.241#53
[1760248636] unbound[7:0] info: query response was ANSWER
[1760248636] unbound[7:0] info: response for . NS IN
...
[1760249061] unbound[7:0] info: service stopped (unbound 1.24.0).
...
```

## Description for the changelog
fix: allow overriding configuration with include directives

## Post scriptum

- Will provide another PR for changing the `include:` to `include-toplevel:` directives.
- In closing, thank you for providing this very usable docker container which is, in contrast to other solutions,
    - up-to-date,
    - distroless,
    - well documented,
    - not that cumbersome in its default settings and configuration approach.

Thx!