### PR TITLE
feat: using include-toplevel directive

### DIFF
--- a/doc/examples/usr/local/unbound/unbound.conf
+++ b/doc/examples/usr/local/unbound/unbound.conf
@@ -6,5 +6,5 @@ server:
 	do-daemonize: no
 	tls-cert-bundle: /etc/ssl/certs/ca-certificates.crt
 
-include: "/usr/local/unbound/conf.d/*.conf"
-include: "/usr/local/unbound/zones.d/*.conf"
+include-toplevel: "/usr/local/unbound/conf.d/*.conf"
+include-toplevel: "/usr/local/unbound/zones.d/*.conf"

--- a/unbound/root/usr/local/unbound/unbound.conf
+++ b/unbound/root/usr/local/unbound/unbound.conf
@@ -1318,5 +1318,5 @@ auth-zone:
 #     tags: "example"
 
 # Allow to include other config files that override settings made here
-include: "/usr/local/unbound/conf.d/*.conf"
-include: "/usr/local/unbound/zones.d/*.conf"
+include-toplevel: "/usr/local/unbound/conf.d/*.conf"
+include-toplevel: "/usr/local/unbound/zones.d/*.conf"


### PR DESCRIPTION
Using `include-toplevel` directive instead of `include` for better include management.

<!--
Please make sure you've read and understood my [`Contributing Guidelines`](https://github.com/madnuttah/unbound-docker/blob/main/CONTRIBUTING.md)

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

This change replaces the `include:` statements by `include-toplevel:` statements in the `unbound.conf`.

In contrast to the `include:` statement, the `include-toplevel:` statement enforces usage of an opening clause (e.g. `server:`, `remote-control:`, `stub-zone` etc.) because the current clause gets closed by the previous include (or file section before the `include-toplevel:`).  Otherwise, the order of files `include`d would matter and statements from previous conf files could change the section that the next one is parsed in (cf. [unbound discussion about introduction of `include-toplevel`](https://github.com/NLnetLabs/unbound/issues/710#issuecomment-1173627501)).

> Distros have changed their include to have the include-toplevel used. That is to make the .conf files more separate from each other.  

Also citing the `unbound.conf(1)` documentation:

> 

**- How I did it**

**- How to verify it**



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
feat: Use `include-toplevel` directive instead of `include` for better include management

## PS – as usually ;-)

- The PR template used is referring to an non-existing [`Contributing Guidelines`](https://github.com/madnuttah/unbound-docker/blob/main/CONTRIBUTING.md
- I'm struggling a bit with the PR template sections: What's the difference of the sections "What I did" and "How I did it"?  I could understand difference in being "what problem is the PR addressing" (the _why_), "what's the achievement" (hmm, also a _why_) – which both are "missing" – and "what/how was this done" (the _what_?), though not reading it the way it's given.
- Thank you for quickly merging my previous PR! :-*